### PR TITLE
Disable automatic backfilling

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-worker1: python pulse_actions/worker.py --topic-base backfilling
+worker1: python pulse_actions/worker.py --topic-base backfilling --dry-run
 worker2: python pulse_actions/worker.py --topic-base resultset_actions,manual_backfill
 


### PR DESCRIPTION
I would like to disable this until we take hidden jobs into consideration.
We're probably adding extra load unintentionally:
https://bugzilla.mozilla.org/show_bug.cgi?id=1197223